### PR TITLE
Resolves issue #18: Any arguments can be included in a log event with…

### DIFF
--- a/src/Logfile.Core/Details/Arguments.cs
+++ b/src/Logfile.Core/Details/Arguments.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Logfile.Core.Details
+{
+	/// <summary>
+	/// Represents arbitrary log event arguments.
+	/// </summary>
+	public class Arguments
+	{
+		/// <summary>
+		/// Get the arguments with their optional names.
+		/// </summary>
+		public IEnumerable<(string Name, object Value)> Values { get; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Arguments"/> class.
+		/// </summary>
+		/// <param name="values">The arguments with their optional names.</param>
+		public Arguments(IEnumerable<(string Name, object Value)> values)
+		{
+			this.Values = values;
+		}
+
+		/// <summary>
+		/// Outputs the arguments with their optional names as a string.
+		/// </summary>
+		/// <returns>The string.</returns>
+		public override string ToString()
+		{
+			var sb = new StringBuilder();
+			sb.Append("{");
+
+			if (this.Values?.Any() == true)
+			{
+				var first = true;
+				foreach (var arg in this.Values)
+				{
+					if (!first)
+						sb.Append(",");
+					else
+						first = false;
+
+					if (!string.IsNullOrEmpty(arg.Name))
+						sb.Append($"{arg.Name}=");
+
+					if (arg.Value == null)
+						sb.Append("null");
+					else
+						sb.Append($@"""{arg.Value}""");
+				}
+			}
+
+			sb.Append("}");
+			return sb.ToString();
+		}
+	}
+
+	/// <summary>
+	/// Implements extension methods for arguments event details.
+	/// </summary>
+	public static class ArgumentsExtensions
+	{
+		/// <summary>
+		/// Adds arbitrary <paramref name="args"/> to a <paramref name="logEvent"/>.
+		/// </summary>
+		/// <typeparam name="TLoglevel">The loglevel type.</typeparam>
+		/// <param name="logEvent">The log event to extend.</param>
+		/// <param name="args">The arguments. If null, the
+		///		<paramref name="logEvent"/> will not get extended.</param>
+		/// <returns>The same <paramref name="logEvent"/> to chain calls.</returns>
+		/// <exception cref="ArgumentNullException">Thrown, if
+		///		<paramref name="logEvent"/> is null.</exception>
+		public static LogEvent<TLoglevel> Args<TLoglevel>(this LogEvent<TLoglevel> logEvent,
+			params object[] args)
+			where TLoglevel : Enum
+		=> NamedArgs(logEvent, args: args?.Select<object, (string Name, object Value)>(a => (Name: null, Value: a)).ToArray());
+
+		/// <summary>
+		/// Adds arbitrary <paramref name="args"/> with names and values
+		///		to a <paramref name="logEvent"/>.
+		/// </summary>
+		/// <typeparam name="TLoglevel">The loglevel type.</typeparam>
+		/// <param name="logEvent">The log event to extend.</param>
+		/// <param name="args">The arguments with names and values. The names
+		///		can be null. If <paramref name="args"/> is null, the
+		///		<paramref name="logEvent"/> will not get extended.</param>
+		/// <returns>The same <paramref name="logEvent"/> to chain calls.</returns>
+		/// <exception cref="ArgumentNullException">Thrown, if
+		///		<paramref name="logEvent"/> is null.</exception>
+		public static LogEvent<TLoglevel> NamedArgs<TLoglevel>(this LogEvent<TLoglevel> logEvent,
+			params (string Name, object Value)[] args)
+			where TLoglevel : Enum
+		{
+			if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+
+			if (args != null)
+			{
+				var arguments = new Arguments(args);
+				logEvent.Details.Add(arguments);
+			}
+
+			return logEvent;
+		}
+
+		/// <summary>
+		/// Adds an <paramref name="obj"/>'s public instance properties and
+		/// values to a <paramref name="logEvent"/> as arguments.
+		/// </summary>
+		/// <typeparam name="TLoglevel">The loglevel type.</typeparam>
+		/// <param name="logEvent">The log event to extend.</param>
+		/// <param name="obj">The object. If null, the
+		///		<paramref name="logEvent"/> will not get extended. If any
+		///		public property's getter throws an exception, the message
+		///		text will be used as value.</param>
+		///	<param name="stringify">true to immediately use every property's
+		///		<c>ToString</c> method result, instead of retaining the original
+		///		property value's reference, false to keep the every property's
+		///		original value reference.</param>
+		/// <returns>The same <paramref name="logEvent"/> to chain calls.</returns>
+		/// <exception cref="ArgumentNullException">Thrown, if
+		///		<paramref name="logEvent"/> is null.</exception>
+		public static LogEvent<TLoglevel> Props<TLoglevel>(this LogEvent<TLoglevel> logEvent,
+			object obj, bool stringify = false)
+			where TLoglevel : Enum
+		{
+			if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+
+			if (obj != null)
+			{
+				var results = new List<(string Name, object Value)>();
+				var type = obj.GetType();
+				var props = type.GetProperties(System.Reflection.BindingFlags.Instance
+												| System.Reflection.BindingFlags.Public);
+				foreach (var p in props)
+				{
+					object value;
+					try
+					{
+						value = p.GetValue(obj);
+						if (value != null && !(value is string) && stringify)
+							value = value?.ToString();
+					}
+					catch (TargetInvocationException tex)
+					{
+						value = tex.InnerException.Message;
+					}
+					catch (Exception ex)
+					{
+						value = ex.Message;
+					}
+
+					results.Add((Name: p.Name, Value: value));
+				}
+
+				NamedArgs(logEvent, args: results.ToArray());
+			}
+
+			return logEvent;
+		}
+	}
+}

--- a/tests/Logfile.Core.UnitTests/Details/ArgumentsTest.cs
+++ b/tests/Logfile.Core.UnitTests/Details/ArgumentsTest.cs
@@ -1,0 +1,300 @@
+﻿using FluentAssertions;
+using Logfile.Core.Details;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace Logfile.Core.UnitTests.Details
+{
+	static class ArgumentsTest
+	{
+		private static LogEvent<StandardLoglevel> createEvent()
+			=> new LogEvent<StandardLoglevel>(logCallback: evt => { }, loglevel: StandardLoglevel.Warning);
+
+		public class Constructors
+		{
+			[Test]
+			public void ArgumentsNull_Should_SetPropertiesAndOutputArgumentsAsString()
+			{
+				// Arrange
+				// Act
+				var args = new Arguments(values: null);
+
+				// Assert
+				args.Values.Should().BeNull();
+				args.ToString().Should().Be("{}");
+			}
+
+			[Test]
+			public void WithArguments_Should_SetPropertiesAndOutputArgumentsAsString()
+			{
+				// Arrange
+				var values = new (string Name, object Value)[] {
+					(Name: "a", Value: 1),
+					(Name: "b", Value: "Berta"),
+					(Name: "c", Value: new object()),
+				};
+
+				// Act
+				var args = new Arguments(values: values);
+
+				// Assert
+				args.Values.Count().Should().Be(values.Count());
+				for (int i = 0; i < values.Count(); i++)
+				{
+					var originalValue = values.ElementAt(i);
+					var argValue = args.Values.ElementAt(i);
+					originalValue.Name.Should().Be(argValue.Name);
+					originalValue.Value.Should().Be(argValue.Value);
+				}
+
+				args.ToString().Should().Be($@"{{a=""1"",b=""Berta"",c=""System.Object""}}");
+			}
+
+			[Test]
+			public void WithArgumentsContainingNullNameAndNullValue_Should_SetPropertiesAndOutputArgumentsAsString()
+			{
+				// Arrange
+				var values = new (string Name, object Value)[] {
+					(Name: "a", Value: 1),
+					(Name: "b", Value: null),
+					(Name: null, Value: "c"),
+					(Name: null, Value: null),
+					(Name: "e", Value: "Emil"),
+				};
+
+				// Act
+				var args = new Arguments(values: values);
+
+				// Assert
+				args.Values.Count().Should().Be(values.Count());
+				for (int i = 0; i < values.Count(); i++)
+				{
+					var originalValue = values.ElementAt(i);
+					var argValue = args.Values.ElementAt(i);
+					originalValue.Name.Should().Be(argValue.Name);
+					originalValue.Value.Should().Be(argValue.Value);
+				}
+
+				args.ToString().Should().Be($@"{{a=""1"",b=null,""c"",null,e=""Emil""}}");
+			}
+		}
+
+		public static class ExtensionMethods
+		{
+			public class ArgsWithoutNames
+			{
+				[Test]
+				public void LogEventNull_ShouldThrow_ArgumentNullException()
+				{
+					// Arrange
+					// Act & Assert
+					Assert.Throws<ArgumentNullException>(
+						() => ArgumentsExtensions.Args<StandardLoglevel>(logEvent: null, "test"));
+				}
+
+				[Test]
+				public void ArgsNull_Should_NotAddArgumentsDetails()
+				{
+					// Arrange
+					var logEvent = createEvent();
+
+					// Act
+					ArgumentsExtensions.Args(logEvent, args: null);
+
+					// Assert
+					logEvent.Details.OfType<Arguments>().Any().Should().BeFalse();
+				}
+
+				[Test]
+				public void ArgsEmpty_Should_AddEmptyArgumentsDetails()
+				{
+					// Arrange
+					var logEvent = createEvent();
+
+					// Act
+					ArgumentsExtensions.Args(logEvent, args: new object[0]);
+
+					// Assert
+					logEvent.Details.OfType<Arguments>().Single().Values.Any().Should().BeFalse();
+				}
+
+				[Test]
+				public void MultipleArgumentsDetails_Should_BeKeptSeparately()
+				{
+					// Arrange
+					var logEvent = createEvent();
+
+					// Act
+					ArgumentsExtensions.Args(logEvent, args: new object[] { "a" });
+					ArgumentsExtensions.Args(logEvent, args: new object[] { "b" });
+
+					// Assert
+					logEvent.Details.OfType<Arguments>().First().Values.Single().Value.Should().Be("a");
+					logEvent.Details.OfType<Arguments>().Last().Values.Single().Value.Should().Be("b");
+				}
+			}
+
+			public class ArgsWithNames
+			{
+				[Test]
+				public void LogEventNull_ShouldThrow_ArgumentNullException()
+				{
+					// Arrange
+					// Act & Assert
+					Assert.Throws<ArgumentNullException>(
+						() => ArgumentsExtensions.NamedArgs<StandardLoglevel>(
+							logEvent: null,
+							new (string Name, object Value)[] { (Name: "name", Value: "test") }));
+				}
+
+				[Test]
+				public void ArgsNull_Should_NotAddArgumentsDetails()
+				{
+					// Arrange
+					var logEvent = createEvent();
+
+					// Act
+					ArgumentsExtensions.NamedArgs(logEvent, args: null);
+
+					// Assert
+					logEvent.Details.OfType<Arguments>().Any().Should().BeFalse();
+				}
+
+				[Test]
+				public void ArgsEmpty_Should_AddEmptyArgumentsDetails()
+				{
+					// Arrange
+					var logEvent = createEvent();
+
+					// Act
+					ArgumentsExtensions.NamedArgs(logEvent, args: new (string Name, object Value)[0]);
+
+					// Assert
+					logEvent.Details.OfType<Arguments>().Single().Values.Any().Should().BeFalse();
+				}
+
+				[Test]
+				public void MultipleArgumentsDetails_Should_BeKeptSeparately()
+				{
+					// Arrange
+					var logEvent = createEvent();
+
+					// Act
+					ArgumentsExtensions.NamedArgs(logEvent, args: new (string Name, object Value)[] { (Name: "1", Value: "a") });
+					ArgumentsExtensions.NamedArgs(logEvent, args: new (string Name, object Value)[] { (Name: "2", Value: "b") });
+
+					// Assert
+					logEvent.Details.OfType<Arguments>().First().Values.Single().Name.Should().Be("1");
+					logEvent.Details.OfType<Arguments>().First().Values.Single().Value.Should().Be("a");
+					logEvent.Details.OfType<Arguments>().Last().Values.Single().Name.Should().Be("2");
+					logEvent.Details.OfType<Arguments>().Last().Values.Single().Value.Should().Be("b");
+				}
+			}
+
+			public class Properties
+			{
+				private class TestClass
+				{
+					public string Text { get; set; }
+					public int Number { get; set; }
+					private bool flag { get; set; } = true;
+				}
+
+				private class TestGetterExceptionClass
+				{
+					public string Text { get => throw new Exception("message"); }
+				}
+
+				private class TestToStringExceptionClass
+				{
+					public TestProperty Property { get; set; } = new TestProperty();
+				}
+
+				private class TestProperty
+				{
+					public override string ToString() => throw new Exception("message");
+				}
+
+				[Test]
+				public void LogEventNull_ShouldThrow_ArgumentNullException()
+				{
+					// Arrange
+					// Act & Assert
+					Assert.Throws<ArgumentNullException>(
+						() => ArgumentsExtensions.Props<StandardLoglevel>(logEvent: null, obj: null));
+				}
+
+				[Test]
+				public void ObjectWithNoProperties_Should_AddEmptyArgumentsDetails()
+				{
+					// Arrange
+					var logEvent = createEvent();
+
+					// Act
+					ArgumentsExtensions.Props(logEvent, obj: new { });
+
+					// Assert
+					logEvent.Details.OfType<Arguments>().Single().Values.Any().Should().BeFalse();
+				}
+
+				[Test]
+				public void ObjectWithPrivateProperties_Should_IgnorePrivateProperties()
+				{
+					// Arrange
+					var logEvent = createEvent();
+					var obj = new TestClass { Text = "test", Number = 1337 };
+
+					// Act
+					ArgumentsExtensions.Props(logEvent, obj);
+
+					// Assert
+					logEvent.Details.OfType<Arguments>().Single().Values.Count().Should().Be(2);
+					logEvent.Details.OfType<Arguments>().Single().Values.Should().Contain((Name: nameof(TestClass.Text), obj.Text));
+					logEvent.Details.OfType<Arguments>().Single().Values.Should().Contain((Name: nameof(TestClass.Number), obj.Number));
+				}
+
+				[Test]
+				public void MultipleArgumentsDetails_Should_BeKeptSeparately()
+				{
+					// Arrange
+					var logEvent = createEvent();
+
+					// Act
+					ArgumentsExtensions.NamedArgs(logEvent, args: new (string Name, object Value)[] { (Name: "1", Value: "a") });
+					ArgumentsExtensions.NamedArgs(logEvent, args: new (string Name, object Value)[] { (Name: "2", Value: "b") });
+
+					// Assert
+					logEvent.Details.OfType<Arguments>().First().Values.Single().Name.Should().Be("1");
+					logEvent.Details.OfType<Arguments>().First().Values.Single().Value.Should().Be("a");
+					logEvent.Details.OfType<Arguments>().Last().Values.Single().Name.Should().Be("2");
+					logEvent.Details.OfType<Arguments>().Last().Values.Single().Value.Should().Be("b");
+				}
+
+				[Test]
+				public void ExceptionInPropertyGetter_Should_UseExceptionMessageAsValue()
+				{
+					var logEvent = createEvent();
+
+					// Act
+					ArgumentsExtensions.Props(logEvent, new TestGetterExceptionClass());
+
+					// Assert
+					logEvent.Details.OfType<Arguments>().Single().Values.Single().Should().Be((nameof(TestGetterExceptionClass.Text), "message"));
+				}
+
+				[Test]
+				public void ExceptionInPropertyToStringWhileStringifying_Should_UseExceptionMessageAsValue()
+				{
+					var logEvent = createEvent();
+
+					// Act
+					ArgumentsExtensions.Props(logEvent, new TestToStringExceptionClass(), stringify: true);
+
+					// Assert
+					logEvent.Details.OfType<Arguments>().Single().Values.Single().Should().Be((nameof(TestToStringExceptionClass.Property), "message"));
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
… or without parameter names. (Anonymous) Objects' properties can be included in a log event with their names and values.